### PR TITLE
Escape non-ASCII quotation marks to fix R CMD check WARNING

### DIFF
--- a/R/plots.R
+++ b/R/plots.R
@@ -40,7 +40,7 @@ stem_plot_title <- function(data, item_name, quote = FALSE) {
   }
 
   if (quote) {
-    title <- paste0("„", title, "“")
+    title <- paste0("\u201e", title, "\u201c")
   }
 
   title

--- a/tests/testthat/test-plots.R
+++ b/tests/testthat/test-plots.R
@@ -47,10 +47,10 @@ test_that("title_quote wraps the title in low/high double quotes", {
   attr(labelled$police, "label") <- "Trust in the police"
 
   p_bar <- stem_barplot(labelled, police, title_show = TRUE, title_quote = TRUE)
-  expect_identical(p_bar$labels$title, "„Trust in the police“")
+  expect_identical(p_bar$labels$title, "\u201eTrust in the police\u201c")
 
   p_inline <- stem_inline(labelled, police, title_show = TRUE, title_quote = TRUE)
-  expect_identical(p_inline$labels$title, "„Trust in the police“")
+  expect_identical(p_inline$labels$title, "\u201eTrust in the police\u201c")
 })
 
 test_that("title_show falls back to the variable name when no label is present", {
@@ -65,7 +65,7 @@ test_that("title_show falls back to the variable name when no label is present",
 
   # Fallback name is quoted too when requested.
   p_quoted <- stem_barplot(no_label, police, title_show = TRUE, title_quote = TRUE)
-  expect_identical(p_quoted$labels$title, "„police“")
+  expect_identical(p_quoted$labels$title, "\u201epolice\u201c")
 })
 
 test_that("stem_battery builds for a set of like items", {


### PR DESCRIPTION
R CMD check flags non-ASCII characters in R code string literals. Replace the literal „ / " quotation marks with their „ / “ escapes in stem_plot_title() and the corresponding tests. R CMD check is now clean (Status: OK).